### PR TITLE
Add all special characters to the regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var regexOptions,
 
 regexOptions = {
   uppercase    : '.*[A-Z]',
-  special      : '.*[!@#$&*]',
+  special      : '.*[^A-Za-z0-9]',
   digit        : '.*[0-9]',
   lowercase    : '.*[a-z]',
   upperLower   : '.*[a-zA-Z]',


### PR DESCRIPTION
Used a negative match to include special characters like `.`, `{`, etc.
